### PR TITLE
fix: remove duplicate Sentiment Analysis heading from table component

### DIFF
--- a/components/table/table.twig
+++ b/components/table/table.twig
@@ -1,10 +1,5 @@
 <div class="layer-wrapper gin-layer-wrapper">
     <table class="analyze--table" role="presentation">
-        <thead>
-            <tr>
-                <th colspan="2" class="header">{{ table_title|t }}</th>
-            </tr>
-        </thead>
         <tbody>
             {% for row in rows %}
                 <tr class="row-{{ row.index }} d{% if loop.index is divisible by(2) %}even{% else %}odd{% endif %}">


### PR DESCRIPTION
1. Summary
  This PR addresses issue #3517391, where the “Sentiment Analysis” heading was appearing multiple times on the reports page (/node/{nid}/analyze/ai_sentiment_analyzer). The duplication came from the table component’s <thead> markup being rendered along with other titles, resulting in multiple headings.

Change details
- Removed the redundant <thead> section from components/table/table.twig.
- The table now only renders rows inside <tbody>, preventing duplicate headings.

2. Steps to reproduce the original issue
- Configure Sentiment Analyzer for a content type.
- View a node and go to Analyze → Sentiment Analysis.
- Observe multiple “Sentiment Analysis” headings.

3. Verification steps
- Apply this branch.
- Repeat the steps above.
- Confirm that the heading appears only once.

`Scope / Risk`
Low. Only affects the markup in the analyze module’s table component. No functional changes.