### PR TITLE
Add AnalyzeSelectFilter Views plugin for dropdown filters

### DIFF
--- a/modules/analyze_basic_content_info/src/Plugin/Analyze/ContentInfo.php
+++ b/modules/analyze_basic_content_info/src/Plugin/Analyze/ContentInfo.php
@@ -39,14 +39,14 @@ final class ContentInfo extends AnalyzePluginBase {
    *   Analyze helper service.
    * @param \Drupal\Core\Session\AccountProxyInterface $currentUser
    *   The current user.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   Entity type manager.
    * @param \Drupal\Core\Render\RendererInterface $renderer
    *   The renderer service.
    * @param \Drupal\Core\Language\LanguageManagerInterface $languageManager
    *   The language manager service.
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
-   *   The config factory.
    */
   public function __construct(
     array $configuration,

--- a/modules/analyze_google_analytics/analyze_google_analytics.install
+++ b/modules/analyze_google_analytics/analyze_google_analytics.install
@@ -31,3 +31,20 @@ function analyze_google_analytics_uninstall(): void {
   // Uninstall our views.
   \Drupal::configFactory()->getEditable('views.view.analyze_google_analytics')->delete();
 }
+
+/**
+ * Update view: standardize submit button text.
+ */
+function analyze_google_analytics_update_8001() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('views.view.analyze_google_analytics');
+
+  if ($config->isNew()) {
+    return t('View not found.');
+  }
+
+  $config->set('display.default.display_options.exposed_form.options.submit_button', 'Apply filters');
+  $config->save();
+
+  return t('Updated submit button text to "Apply filters".');
+}

--- a/modules/analyze_google_analytics/config/install/views.view.analyze_google_analytics.yml
+++ b/modules/analyze_google_analytics/config/install/views.view.analyze_google_analytics.yml
@@ -178,7 +178,7 @@ display:
       exposed_form:
         type: basic
         options:
-          submit_button: Apply
+          submit_button: 'Apply filters'
           reset_button: false
           reset_button_label: Reset
           exposed_sorts_label: 'Sort by'

--- a/src/Plugin/views/filter/AnalyzeSelectFilter.php
+++ b/src/Plugin/views/filter/AnalyzeSelectFilter.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Drupal\analyze\Plugin\views\filter;
+
+use Drupal\Core\Database\Connection;
+use Drupal\views\Plugin\views\filter\InOperator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Filter handler providing a select list from database values.
+ *
+ * Supports three modes for getting options:
+ * - options_callback: Call a service method to get options array.
+ * - options_table: Query a separate table for id/label pairs.
+ * - Fallback: Query distinct values from the current table/field.
+ *
+ * @ViewsFilter("analyze_select")
+ */
+final class AnalyzeSelectFilter extends InOperator {
+
+  /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected Connection $database;
+
+  /**
+   * The service container.
+   *
+   * @var \Symfony\Component\DependencyInjection\ContainerInterface
+   */
+  protected ContainerInterface $container;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, Connection $database, ContainerInterface $container) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->database = $database;
+    $this->container = $container;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new self(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('database'),
+      $container
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValueOptions(): array {
+    if ($this->valueOptions !== NULL) {
+      return $this->valueOptions;
+    }
+
+    // Try options_callback first (service:method format).
+    if (!empty($this->definition['options_callback'])) {
+      $this->valueOptions = $this->getOptionsFromCallback();
+      return $this->valueOptions;
+    }
+
+    // Try options_table with id/label columns.
+    if (!empty($this->definition['options_table'])) {
+      $this->valueOptions = $this->getOptionsFromTable();
+      return $this->valueOptions;
+    }
+
+    // Fallback: query distinct values from current table/field.
+    $this->valueOptions = $this->getOptionsFromDistinct();
+    return $this->valueOptions;
+  }
+
+  /**
+   * Get options from a service callback.
+   *
+   * @return array
+   *   Options array keyed by id with label values.
+   */
+  protected function getOptionsFromCallback(): array {
+    $callback = $this->definition['options_callback'];
+    [$service_id, $method] = explode(':', $callback);
+
+    $service = $this->container->get($service_id);
+    if (method_exists($service, $method)) {
+      return $service->$method();
+    }
+
+    return [];
+  }
+
+  /**
+   * Get options from a separate database table.
+   *
+   * @return array
+   *   Options array keyed by id with label values.
+   */
+  protected function getOptionsFromTable(): array {
+    $table = $this->definition['options_table'];
+    $id_column = $this->definition['options_id_column'] ?? 'id';
+    $label_column = $this->definition['options_label_column'] ?? $id_column;
+
+    $query = $this->database->select($table, 't')
+      ->fields('t', [$id_column, $label_column])
+      ->orderBy($label_column);
+
+    // Add status filter if the table has a status column.
+    if (!empty($this->definition['options_status_column'])) {
+      $query->condition($this->definition['options_status_column'], 1);
+    }
+
+    $results = $query->execute()->fetchAllKeyed();
+
+    return $results;
+  }
+
+  /**
+   * Get options from distinct values in the current table.
+   *
+   * @return array
+   *   Options array with same key and value.
+   */
+  protected function getOptionsFromDistinct(): array {
+    $field = $this->realField;
+    $table = $this->table;
+
+    $values = $this->database->select($table, 't')
+      ->fields('t', [$field])
+      ->distinct()
+      ->orderBy($field)
+      ->execute()
+      ->fetchCol();
+
+    return array_combine($values, $values);
+  }
+
+}


### PR DESCRIPTION
## Summary

Add a reusable Views filter plugin that provides select dropdown functionality for analyze submodules.

Supports three ways to populate options:
1. **options_callback** - Service method callback (e.g., `analyze_ai_sentiments.storage:getSentimentOptions`)
2. **options_table** - Database table with id/label columns  
3. **Fallback** - Query distinct values from the filter's field

Also includes:
- Fix docblock parameter order in ContentInfo.php
- Standardize submit button to "Apply filters" in analyze_google_analytics view

## Test plan
- [ ] Enable an analyze submodule that uses this filter (sentiments, security audit, or marketing audit)
- [ ] Verify the filter renders as a select dropdown instead of text input
- [ ] Run `drush cr` to rebuild caches after enabling

Closes #10