### PR TITLE
Fix batch assembly timeout, progress tracking, and error reporting

### DIFF
--- a/src/AnalyzePluginBase.php
+++ b/src/AnalyzePluginBase.php
@@ -171,6 +171,13 @@ abstract class AnalyzePluginBase extends PluginBase implements AnalyzeInterface,
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function getAnalyzedEntityIds(string $entity_type_id, string $bundle): array {
+    return [];
+  }
+
+  /**
    * Gets the entity-specific settings for this analyzer.
    *
    * @param string $entity_type_id

--- a/src/BatchableAnalyzerInterface.php
+++ b/src/BatchableAnalyzerInterface.php
@@ -49,4 +49,20 @@ interface BatchableAnalyzerInterface {
    */
   public function hasResults(EntityInterface $entity): bool;
 
+  /**
+   * Gets entity IDs that have stored results for a given type and bundle.
+   *
+   * Used during batch assembly to exclude already-analyzed entities without
+   * loading or rendering them. Implementations should use a direct DB query.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param string $bundle
+   *   The bundle.
+   *
+   * @return array<string|int>
+   *   Array of entity IDs with existing results.
+   */
+  public function getAnalyzedEntityIds(string $entity_type_id, string $bundle): array;
+
 }

--- a/src/Form/AnalyzeBatchForm.php
+++ b/src/Form/AnalyzeBatchForm.php
@@ -164,23 +164,40 @@ final class AnalyzeBatchForm extends FormBase {
    *   The remaining operations.
    */
   public static function batchFinished(bool $success, array $results, array $operations): void {
-    if ($success) {
-      $processed = $results['processed'] ?? 0;
+    if (!$success) {
+      \Drupal::messenger()->addError(t('Batch analysis processing failed.'));
+      return;
+    }
+
+    $processed = $results['processed'] ?? 0;
+    $failed = $results['failed'] ?? 0;
+
+    if ($processed > 0) {
       \Drupal::messenger()->addStatus(\Drupal::translation()->formatPlural(
         $processed,
         'Successfully analyzed @count entity.',
         'Successfully analyzed @count entities.',
         ['@count' => $processed]
       ));
+    }
 
-      if (!empty($results['errors'])) {
-        foreach ($results['errors'] as $error) {
-          \Drupal::messenger()->addError($error);
-        }
+    if ($failed > 0) {
+      \Drupal::messenger()->addError(\Drupal::translation()->formatPlural(
+        $failed,
+        'Failed to analyze @count entity.',
+        'Failed to analyze @count entities.',
+        ['@count' => $failed]
+      ));
+    }
+
+    if (!empty($results['errors'])) {
+      foreach ($results['errors'] as $error) {
+        \Drupal::messenger()->addError($error);
       }
     }
-    else {
-      \Drupal::messenger()->addError(t('Batch analysis processing failed.'));
+
+    if ($processed === 0 && $failed === 0) {
+      \Drupal::messenger()->addWarning(t('No entities were processed.'));
     }
   }
 

--- a/src/Service/AnalyzeBatchService.php
+++ b/src/Service/AnalyzeBatchService.php
@@ -320,12 +320,9 @@ final class AnalyzeBatchService {
       '@max' => $context['sandbox']['total_entities'],
     ])->render();
 
-    if ($context['sandbox']['total_entities'] > 0) {
-      $context['finished'] = $done / $context['sandbox']['total_entities'];
-    }
-    else {
-      $context['finished'] = 1;
-    }
+    // Each chunk is a separate batch operation, so mark it complete.
+    // Drupal advances to the next operation when finished >= 1.
+    $context['finished'] = 1;
   }
 
   /**
@@ -372,7 +369,8 @@ final class AnalyzeBatchService {
   /**
    * Gets entity IDs that have results from ALL specified analyzers.
    *
-   * Uses chunked loading to avoid memory issues on large sites.
+   * Uses getAnalyzedEntityIds() on each plugin to query the database
+   * directly, avoiding entity loading and rendering.
    *
    * @param array<string> $analyzer_ids
    *   Array of analyzer plugin IDs.
@@ -385,58 +383,30 @@ final class AnalyzeBatchService {
    *   Array of entity IDs that have results from all analyzers.
    */
   private function getFullyAnalyzedEntityIds(array $analyzer_ids, string $entity_type_id, string $bundle): array {
-    $storage = $this->entityTypeManager->getStorage($entity_type_id);
-    $entity_type = $this->entityTypeManager->getDefinition($entity_type_id);
-    $query = $storage->getQuery();
-    $query->accessCheck(FALSE);
+    $per_analyzer_ids = [];
 
-    $bundle_key = $entity_type->getKey('bundle');
-    if ($bundle_key) {
-      $query->condition($bundle_key, $bundle);
-    }
-
-    $all_ids = $query->execute();
-    if (empty($all_ids)) {
-      return [];
-    }
-
-    $analyzers = [];
     foreach ($analyzer_ids as $analyzer_id) {
       $plugin = $this->analyzePluginManager->createInstance($analyzer_id);
       if ($plugin instanceof BatchableAnalyzerInterface) {
-        $analyzers[$analyzer_id] = $plugin;
+        $ids = $plugin->getAnalyzedEntityIds($entity_type_id, $bundle);
+        if (empty($ids)) {
+          return [];
+        }
+        $per_analyzer_ids[] = array_map('strval', $ids);
       }
     }
 
-    if (empty($analyzers)) {
+    if (empty($per_analyzer_ids)) {
       return [];
     }
 
-    $analyzed_ids = [];
-    foreach (array_chunk($all_ids, 50, TRUE) as $chunk) {
-      $entities = $storage->loadMultiple($chunk);
-      foreach ($entities as $id => $entity) {
-        try {
-          $all_have_results = TRUE;
-          foreach ($analyzers as $analyzer) {
-            if (!$analyzer->hasResults($entity)) {
-              $all_have_results = FALSE;
-              break;
-            }
-          }
-          if ($all_have_results) {
-            $analyzed_ids[] = $id;
-          }
-        }
-        catch (\Exception) {
-          // Entity type may lack a view_builder — skip it.
-        }
-      }
-      // Clear static entity cache to keep memory flat.
-      $storage->resetCache($chunk);
+    // Intersect: only IDs present in ALL analyzers are fully analyzed.
+    $analyzed_ids = array_shift($per_analyzer_ids);
+    foreach ($per_analyzer_ids as $ids) {
+      $analyzed_ids = array_intersect($analyzed_ids, $ids);
     }
 
-    return $analyzed_ids;
+    return array_values($analyzed_ids);
   }
 
 }


### PR DESCRIPTION
## Summary

Fixes #18. Three bugs in the centralized batch processing infrastructure:

- **Assembly timeout**: `getFullyAnalyzedEntityIds()` rendered every entity in the bundle via `hasResults()` just to build an exclusion list, causing 504s even with `limit=1`. Replaced with `getAnalyzedEntityIds()` DB queries that never load or render entities.
- **Infinite loop**: `$context['finished']` was calculated as a fraction of total entities across all operations, but each chunk is a separate batch operation. Drupal re-invoked the same operation endlessly. Now sets `finished = 1` per chunk.
- **Silent failures**: `batchFinished()` only reported processed count. Now reports failed count and individual error messages.

## Changes

- Add `getAnalyzedEntityIds()` to `BatchableAnalyzerInterface` with default `[]` in `AnalyzePluginBase`
- Rewrite `getFullyAnalyzedEntityIds()` to intersect per-analyzer DB results
- Fix `$context['finished'] = 1` at end of each chunk operation
- Report failures and errors prominently in `batchFinished()`

## Test plan

- [ ] Run batch with limit < total entities, verify batch completes and advances through all chunks
- [ ] Run batch on a bundle with 1000+ entities, verify no 504 during form submission
- [ ] Trigger an entity rendering error, verify it appears as a named error in the batch results
- [ ] Run batch with force refresh off on already-analyzed content, verify entities are correctly skipped