### PR TITLE
Fix batch assembly timeout by replacing entity rendering with DB queries

### DIFF
--- a/src/AnalyzePluginBase.php
+++ b/src/AnalyzePluginBase.php
@@ -174,6 +174,8 @@ abstract class AnalyzePluginBase extends PluginBase implements AnalyzeInterface,
    * {@inheritdoc}
    */
   public function getAnalyzedEntityIds(string $entity_type_id, string $bundle): array {
+    // Default to no fast-path IDs when a plugin cannot query fresh results
+    // without loading entities. This keeps batch assembly correct.
     return [];
   }
 

--- a/src/AnalyzePluginBase.php
+++ b/src/AnalyzePluginBase.php
@@ -171,6 +171,13 @@ abstract class AnalyzePluginBase extends PluginBase implements AnalyzeInterface,
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function getAnalyzedEntityIds(string $entity_type_id, string $bundle): array {
+    return [];
+  }
+
+  /**
    * Gets the entity-specific settings for this analyzer.
    *
    * @param string $entity_type_id

--- a/src/BatchableAnalyzerInterface.php
+++ b/src/BatchableAnalyzerInterface.php
@@ -49,4 +49,20 @@ interface BatchableAnalyzerInterface {
    */
   public function hasResults(EntityInterface $entity): bool;
 
+  /**
+   * Gets entity IDs that have stored results for a given type and bundle.
+   *
+   * Used during batch assembly to exclude already-analyzed entities without
+   * loading or rendering them. Implementations should use a direct DB query.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param string $bundle
+   *   The bundle.
+   *
+   * @return array<string|int>
+   *   Array of entity IDs with existing results.
+   */
+  public function getAnalyzedEntityIds(string $entity_type_id, string $bundle): array;
+
 }

--- a/src/BatchableAnalyzerInterface.php
+++ b/src/BatchableAnalyzerInterface.php
@@ -50,10 +50,11 @@ interface BatchableAnalyzerInterface {
   public function hasResults(EntityInterface $entity): bool;
 
   /**
-   * Gets entity IDs that have stored results for a given type and bundle.
+   * Gets entity IDs that have current results for a given type and bundle.
    *
    * Used during batch assembly to exclude already-analyzed entities without
-   * loading or rendering them. Implementations should use a direct DB query.
+   * loading or rendering them. Implementations should use a direct DB query
+   * and return an empty array when they cannot safely match hasResults().
    *
    * @param string $entity_type_id
    *   The entity type ID.
@@ -61,7 +62,7 @@ interface BatchableAnalyzerInterface {
    *   The bundle.
    *
    * @return array<string|int>
-   *   Array of entity IDs with existing results.
+   *   Array of entity IDs with current results.
    */
   public function getAnalyzedEntityIds(string $entity_type_id, string $bundle): array;
 

--- a/src/Service/AnalyzeBatchService.php
+++ b/src/Service/AnalyzeBatchService.php
@@ -370,7 +370,7 @@ final class AnalyzeBatchService {
   }
 
   /**
-   * Gets entity IDs that have results from ALL specified analyzers.
+   * Gets entity IDs that have current results from ALL specified analyzers.
    *
    * Uses getAnalyzedEntityIds() on each plugin to query the database
    * directly, avoiding entity loading and rendering.
@@ -383,7 +383,7 @@ final class AnalyzeBatchService {
    *   The bundle.
    *
    * @return array<string|int>
-   *   Array of entity IDs that have results from all analyzers.
+   *   Array of entity IDs that have current results from all analyzers.
    */
   private function getFullyAnalyzedEntityIds(array $analyzer_ids, string $entity_type_id, string $bundle): array {
     $per_analyzer_ids = [];

--- a/src/Service/AnalyzeBatchService.php
+++ b/src/Service/AnalyzeBatchService.php
@@ -372,7 +372,8 @@ final class AnalyzeBatchService {
   /**
    * Gets entity IDs that have results from ALL specified analyzers.
    *
-   * Uses chunked loading to avoid memory issues on large sites.
+   * Uses getAnalyzedEntityIds() on each plugin to query the database
+   * directly, avoiding entity loading and rendering.
    *
    * @param array<string> $analyzer_ids
    *   Array of analyzer plugin IDs.
@@ -385,58 +386,30 @@ final class AnalyzeBatchService {
    *   Array of entity IDs that have results from all analyzers.
    */
   private function getFullyAnalyzedEntityIds(array $analyzer_ids, string $entity_type_id, string $bundle): array {
-    $storage = $this->entityTypeManager->getStorage($entity_type_id);
-    $entity_type = $this->entityTypeManager->getDefinition($entity_type_id);
-    $query = $storage->getQuery();
-    $query->accessCheck(FALSE);
+    $per_analyzer_ids = [];
 
-    $bundle_key = $entity_type->getKey('bundle');
-    if ($bundle_key) {
-      $query->condition($bundle_key, $bundle);
-    }
-
-    $all_ids = $query->execute();
-    if (empty($all_ids)) {
-      return [];
-    }
-
-    $analyzers = [];
     foreach ($analyzer_ids as $analyzer_id) {
       $plugin = $this->analyzePluginManager->createInstance($analyzer_id);
       if ($plugin instanceof BatchableAnalyzerInterface) {
-        $analyzers[$analyzer_id] = $plugin;
+        $ids = $plugin->getAnalyzedEntityIds($entity_type_id, $bundle);
+        if (empty($ids)) {
+          return [];
+        }
+        $per_analyzer_ids[] = array_map('strval', $ids);
       }
     }
 
-    if (empty($analyzers)) {
+    if (empty($per_analyzer_ids)) {
       return [];
     }
 
-    $analyzed_ids = [];
-    foreach (array_chunk($all_ids, 50, TRUE) as $chunk) {
-      $entities = $storage->loadMultiple($chunk);
-      foreach ($entities as $id => $entity) {
-        try {
-          $all_have_results = TRUE;
-          foreach ($analyzers as $analyzer) {
-            if (!$analyzer->hasResults($entity)) {
-              $all_have_results = FALSE;
-              break;
-            }
-          }
-          if ($all_have_results) {
-            $analyzed_ids[] = $id;
-          }
-        }
-        catch (\Exception) {
-          // Entity type may lack a view_builder — skip it.
-        }
-      }
-      // Clear static entity cache to keep memory flat.
-      $storage->resetCache($chunk);
+    // Intersect: only IDs present in ALL analyzers are fully analyzed.
+    $analyzed_ids = array_shift($per_analyzer_ids);
+    foreach ($per_analyzer_ids as $ids) {
+      $analyzed_ids = array_intersect($analyzed_ids, $ids);
     }
 
-    return $analyzed_ids;
+    return array_values($analyzed_ids);
   }
 
 }


### PR DESCRIPTION
## Summary

Fixes #18. `getFullyAnalyzedEntityIds()` loaded every entity in the bundle and called `hasResults()` on each, triggering full entity rendering via `generateContentHash()`. With 1900 nodes this caused a 504 even with `limit=1`.

## Changes

- Add `getAnalyzedEntityIds()` to `BatchableAnalyzerInterface` so plugins can report analyzed entity IDs via direct DB queries
- Add default `[]` implementation in `AnalyzePluginBase`
- Rewrite `getFullyAnalyzedEntityIds()` to intersect per-analyzer DB results without loading or rendering any entities

## Test plan

- [ ] Run batch on a bundle with 1000+ entities, verify no 504 during form submission
- [ ] Run batch with force refresh off on already-analyzed content, verify entities are correctly skipped