### PR TITLE
Fix batch progress tracking causing infinite loop

### DIFF
--- a/src/Service/AnalyzeBatchService.php
+++ b/src/Service/AnalyzeBatchService.php
@@ -320,12 +320,9 @@ final class AnalyzeBatchService {
       '@max' => $context['sandbox']['total_entities'],
     ])->render();
 
-    if ($context['sandbox']['total_entities'] > 0) {
-      $context['finished'] = $done / $context['sandbox']['total_entities'];
-    }
-    else {
-      $context['finished'] = 1;
-    }
+    // Each chunk is a separate batch operation, so mark it complete.
+    // Drupal advances to the next operation when finished >= 1.
+    $context['finished'] = 1;
   }
 
   /**
@@ -429,7 +426,7 @@ final class AnalyzeBatchService {
           }
         }
         catch (\Exception) {
-          // Entity type may lack a view_builder — skip it.
+          // Entity type may lack a view_builder, skip it.
         }
       }
       // Clear static entity cache to keep memory flat.

--- a/src/Service/AnalyzeBatchService.php
+++ b/src/Service/AnalyzeBatchService.php
@@ -236,13 +236,10 @@ final class AnalyzeBatchService {
    *   Batch context.
    */
   public function processBatch(array $entities, array $analyzer_ids, bool $force_refresh, int $total_entities, array &$context): void {
-    if (!isset($context['sandbox']['total_entities'])) {
-      $context['sandbox']['total_entities'] = $total_entities;
-      $context['results']['processed'] = 0;
-      $context['results']['failed'] = 0;
-      $context['results']['rate_limited'] = 0;
-      $context['results']['errors'] = [];
-    }
+    $context['results']['processed'] = $context['results']['processed'] ?? 0;
+    $context['results']['failed'] = $context['results']['failed'] ?? 0;
+    $context['results']['rate_limited'] = $context['results']['rate_limited'] ?? 0;
+    $context['results']['errors'] = $context['results']['errors'] ?? [];
 
     // Build analyzer instances.
     $all_analyzers = [];
@@ -317,7 +314,7 @@ final class AnalyzeBatchService {
     $done = $context['results']['processed'] + $context['results']['failed'];
     $context['message'] = $this->t('Processed @current of @max entities...', [
       '@current' => $done,
-      '@max' => $context['sandbox']['total_entities'],
+      '@max' => $total_entities,
     ])->render();
 
     // Each chunk is a separate batch operation, so mark it complete.


### PR DESCRIPTION
## Summary

Fixes #20. `processBatch()` calculated `$context['finished']` as a fraction of total entities across all operations, but the form creates one batch operation per chunk of 5. After processing a chunk, `finished` was e.g. `5/100 = 0.05`, so Drupal re-invoked the same operation endlessly instead of advancing to the next chunk.

## Changes

- Set `$context['finished'] = 1` at the end of each chunk since each chunk is a separate complete batch operation

## Test plan

- [ ] Run batch with limit < total entities (e.g. 100 on a type with 112 nodes), verify batch completes without Ajax error
- [ ] Verify progress bar advances through all chunks