### PR TITLE
Fix batch error reporting to show failed entity count

### DIFF
--- a/src/Form/AnalyzeBatchForm.php
+++ b/src/Form/AnalyzeBatchForm.php
@@ -164,23 +164,40 @@ final class AnalyzeBatchForm extends FormBase {
    *   The remaining operations.
    */
   public static function batchFinished(bool $success, array $results, array $operations): void {
-    if ($success) {
-      $processed = $results['processed'] ?? 0;
+    if (!$success) {
+      \Drupal::messenger()->addError(t('Batch analysis processing failed.'));
+      return;
+    }
+
+    $processed = $results['processed'] ?? 0;
+    $failed = $results['failed'] ?? 0;
+
+    if ($processed > 0) {
       \Drupal::messenger()->addStatus(\Drupal::translation()->formatPlural(
         $processed,
         'Successfully analyzed @count entity.',
         'Successfully analyzed @count entities.',
         ['@count' => $processed]
       ));
+    }
 
-      if (!empty($results['errors'])) {
-        foreach ($results['errors'] as $error) {
-          \Drupal::messenger()->addError($error);
-        }
+    if ($failed > 0) {
+      \Drupal::messenger()->addError(\Drupal::translation()->formatPlural(
+        $failed,
+        'Failed to analyze @count entity.',
+        'Failed to analyze @count entities.',
+        ['@count' => $failed]
+      ));
+    }
+
+    if (!empty($results['errors'])) {
+      foreach ($results['errors'] as $error) {
+        \Drupal::messenger()->addError($error);
       }
     }
-    else {
-      \Drupal::messenger()->addError(t('Batch analysis processing failed.'));
+
+    if ($processed === 0 && $failed === 0) {
+      \Drupal::messenger()->addWarning(t('No entities were processed.'));
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #21. `batchFinished()` only reported the processed count via a success message. Failed entities were not shown, making it appear that entities were silently skipped (e.g. "successfully checked 5 entities" when 90 others failed due to rendering errors).

## Changes

- Report failed count as a separate error message
- Show individual error details so the user knows which entities failed and why
- Show a warning if no entities were processed at all

## Test plan

- [ ] Trigger an entity rendering error (e.g. recursive media reference), verify the failure appears as a named error
- [ ] Run a successful batch, verify only the success message appears (no spurious failure count)